### PR TITLE
chore: upgrade tonic/prost stack to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,11 @@ prost = { version = "^0.14", default-features = false, features = [
 prost-types = { version = "^0.14", default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
-tonic = { version = "^0.14", features = ["tls-aws-lc"] }
+tonic = { version = "^0.14",  default-features = false,  features = [
+    "channel",
+    "codegen",
+    "tls-aws-lc",
+] }
 tonic-prost = { version = "^0.14", default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,4 @@ anyhow = "1.0"
 tonic-prost-build = { version = "^0.14", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "^1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,43 +15,39 @@ readme = "README.md"
 [features]
 default = ["tls"]
 wasm = []
-tls = ["tonic/tls", "tonic/tls-roots"]
+tls = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost = { version = "^0.10", default-features = false, features = [
-    "prost-derive",
+prost = { version = "^0.14", default-features = false, features = [
+    "std"
 ] }
-prost-types = { version = "^0.10", default-features = false }
+prost-types = { version = "^0.14", default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
-tonic = { version = "^0.7", default-features = false, features = [
-    "codegen",
-    "prost",
-] }
+tonic = { version = "^0.14", features = ["tls-aws-lc"] }
+tonic-prost = { version = "^0.14", default-features = false }
 thiserror = "1.0"
 anyhow = "1.0"
-http = { version = "0.2", default-features = false }
-http-body = { version = "0.4", default-features = false }
+http = { version = "1.3", default-features = false }
+http-body = { version = "1", default-features = false }
 byteorder = { version = "1", default-features = false }
-base64 = { version = "0.13", default-features = false }
+base64 = { version = "0.22", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = [
     "serde-serialize",
 ] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
-wasm-streams = { version = "0.2" }
+wasm-streams = { version = "0.4" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 js-sys = { version = "0.3", default-features = false }
 httparse = { version = "1", default-features = false }
-hyper = { version = "0.14", default-features = false }
+hyper = { version = "1.7", default-features = false }
 
 
 [build-dependencies]
 walkdir = "2"
 anyhow = "1.0"
-tonic-build = { version = "^0.7", default-features = false, features = [
-    "prost",
-] }
+tonic-prost-build = { version = "^0.14", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -6,11 +6,24 @@ This library provides the necessary setup to generate a Triton client from NVIDI
 
 ```rust
 // un-auth'd use of Triton
-let client = Client::new("http://localhost:8001/", None).await?;
-let models = client
-    .repository_index(triton_client::inference::RepositoryIndexRequest {
-        repository_name: "".into(), // This should show us models not referenced by repo name.
-        ready: false,               // show all models, not just ready ones.
-    })
-    .await?;
+use triton_client::Client;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("http://localhost:8001/", None).await?;
+    let models = client
+        .repository_index(triton_client::inference::RepositoryIndexRequest {
+            repository_name: "".into(), // This should show us models not referenced by repo name.
+            ready: false,               // show all models, not just ready ones.
+        })
+        .await?;
+
+    for model in models.models {
+        println!("Name: {}", model.name);
+        println!("Version: {:?}", model.version);
+        println!("State: {:?}", model.state);
+        println!("---------------");
+    }
+
+    Ok(())
+}
 ```

--- a/build.rs
+++ b/build.rs
@@ -35,9 +35,9 @@ fn main() -> Result<()> {
         println!("cargo:rerun-if-changed={}", path.display());
     }
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
-        .compile(&protobuf_paths, &[&pb_dir])
+        .compile_protos(&protobuf_paths, &[pb_dir])
         .context("unable to compile Protocol Buffers for the Triton client")?;
 
     Ok(())


### PR DESCRIPTION
- upgrade tonic to 0.14 and adopt tonic-prost crates

- bump prost and prost-types to 0.14

- refresh http, http-body, hyper, base64, and wasm-streams versions

- update build.rs to use tonic_prost_build::compile_protos